### PR TITLE
Task 2-Test Case 8: Added implementation and test to prevent deleting non-existent counters

### DIFF
--- a/tdd_lab/src/counter.py
+++ b/tdd_lab/src/counter.py
@@ -18,6 +18,14 @@ def create_counter(name):
   COUNTERS[name] = 0
   return jsonify({name: COUNTERS[name]}), status.HTTP_201_CREATED
 
+# Function #8: Prevent deleting non-existent counter
+@app.route('/counters/<name>', methods=['DELETE'])
+def deleting_nonexistent_counter(name):
+   '''Prevent deleting non-existent counter'''
+   if not counter_exists(name):
+      return jsonify(name), status.HTTP_409_CONFLICT
+   else:
+      return jsonify(name), status.HTTP_200_OK
 
 # Function #10: List counters
 @app.route('/counters', methods=['GET'])

--- a/tdd_lab/tests/test_counter.py
+++ b/tdd_lab/tests/test_counter.py
@@ -27,6 +27,14 @@ class TestCounterEndpoints:
         result = client.post('/counters/foo')
         assert result.status_code == status.HTTP_201_CREATED
 
+    # Test #8: Prevent deleting non-existent counter
+    def test_deleting_nonexistent_counter(self, client):
+        '''It should prevent deleting a non-existent counter'''
+        # Attempting to delete counter that doesn't exist
+        result = client.delete('/counters/testcounter')
+        # Check if a conflict status code was returned
+        assert result.status_code == status.HTTP_409_CONFLICT
+
     # Test #10, listing all counters
     def test_list_counters(self, client):
         """It should list all counters"""


### PR DESCRIPTION
Test Case 8: Prevent deleting non-existent counters
Added test case: Attempts to delete a counter that doesn't exist, asserting that the returned status code should be 409 (not 100% sure this is the appropriate status code for this test case)
Added implementation: Checks if the counter exists. Returns 409 error code if it doesn't exist or a 200 status code if it does