### PR TITLE
added test: prevent duplicate counters

### DIFF
--- a/tdd_lab/tests/test_counter.py
+++ b/tdd_lab/tests/test_counter.py
@@ -27,6 +27,16 @@ class TestCounterEndpoints:
         result = client.post('/counters/foo')
         assert result.status_code == status.HTTP_201_CREATED
 
+    # Test #2: Prevent duplicate counters
+    def test_prevent_duplicate_counters(self, client):
+        """It should prevent creating a duplicate counter"""
+        # create a counter
+        client.post('/counters/foo')
+        # attempt to create the same counter
+        result = client.post('/counters/foo')
+        # check if we were successful
+        assert result.status_code == status.HTTP_409_CONFLICT
+
     # Test #8: Prevent deleting non-existent counter
     def test_deleting_nonexistent_counter(self, client):
         '''It should prevent deleting a non-existent counter'''


### PR DESCRIPTION
I created test #2 prevent duplicate counters.

first it creates a counter with the name 'foo', it then creates another counter with the same name 'foo'. If successful, the second post call should return a status of 'HTTP_409_CONFLICT'.
lines modified: 30 - 39